### PR TITLE
[api] /format endpoint returns JSON-encoded BAI2 file

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -153,3 +153,36 @@ paths:
               schema:
                 type: string
                 example: invalid file format
+
+  /format:
+    post:
+      tags: ['Bai2 Files']
+      summary: Format bai2 file after parse bin file
+      description: format bai2 file.
+      operationId: format
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              properties:
+                input:
+                  type: string
+                  description: bai2 bin file
+                  format: binary
+            encoding:
+              file:
+                contentType: text/plain
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: request
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: invalid file format

--- a/cmd/bai2/cmd_test.go
+++ b/cmd/bai2/cmd_test.go
@@ -56,3 +56,10 @@ func TestParse(t *testing.T) {
 		t.Errorf(err.Error())
 	}
 }
+
+func TestFormat(t *testing.T) {
+	_, err := executeCommand(rootCmd, "format", "--input", testFileName)
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+}

--- a/cmd/bai2/main.go
+++ b/cmd/bai2/main.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"encoding/json"
 
 	"github.com/spf13/cobra"
 
@@ -96,6 +97,31 @@ var Print = &cobra.Command{
 	},
 }
 
+var Format = &cobra.Command{
+	Use:   "format",
+	Short: "Format bai2 report",
+	Long:  "Format an incoming bai2 report after parse",
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		var err error
+
+		scan := lib.NewBai2Scanner(bytes.NewReader(documentBuffer))
+		f := lib.NewBai2()
+		err = f.Read(&scan)
+		if err != nil {
+			return err
+		}
+		
+		body, ferr := json.Marshal(f)
+		if ferr != nil {
+			return ferr
+		}
+		
+		fmt.Println(string(body))
+		return nil
+	},
+}
+
 var rootCmd = &cobra.Command{
 	Use:   "",
 	Short: "",
@@ -148,6 +174,7 @@ func initRootCmd() {
 	rootCmd.AddCommand(WebCmd)
 	rootCmd.AddCommand(Print)
 	rootCmd.AddCommand(Parse)
+	rootCmd.AddCommand(Format)
 }
 
 func main() {

--- a/pkg/client/README.md
+++ b/pkg/client/README.md
@@ -79,6 +79,7 @@ All URIs are relative to *http://localhost:8208*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
+*Bai2FilesApi* | [**Format**](docs/Bai2FilesApi.md#format) | **Post** /format | Format bai2 file after parse bin file
 *Bai2FilesApi* | [**Health**](docs/Bai2FilesApi.md#health) | **Get** /health | health bai2 service
 *Bai2FilesApi* | [**Parse**](docs/Bai2FilesApi.md#parse) | **Post** /parse | Parse bai2 file after parse bin file
 *Bai2FilesApi* | [**Print**](docs/Bai2FilesApi.md#print) | **Post** /print | Print bai2 file after parse bin file

--- a/pkg/client/api_bai2_files.go
+++ b/pkg/client/api_bai2_files.go
@@ -27,6 +27,139 @@ var (
 // Bai2FilesApiService Bai2FilesApi service
 type Bai2FilesApiService service
 
+type ApiFormatRequest struct {
+	ctx        context.Context
+	ApiService *Bai2FilesApiService
+	input      **os.File
+}
+
+// bai2 bin file
+func (r ApiFormatRequest) Input(input *os.File) ApiFormatRequest {
+	r.input = &input
+	return r
+}
+
+func (r ApiFormatRequest) Execute() (map[string]interface{}, *http.Response, error) {
+	return r.ApiService.FormatExecute(r)
+}
+
+/*
+Format Format bai2 file after parse bin file
+
+format bai2 file.
+
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiFormatRequest
+*/
+func (a *Bai2FilesApiService) Format(ctx context.Context) ApiFormatRequest {
+	return ApiFormatRequest{
+		ApiService: a,
+		ctx:        ctx,
+	}
+}
+
+// Execute executes the request
+//
+//	@return map[string]interface{}
+func (a *Bai2FilesApiService) FormatExecute(r ApiFormatRequest) (map[string]interface{}, *http.Response, error) {
+	var (
+		localVarHTTPMethod  = http.MethodPost
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue map[string]interface{}
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "Bai2FilesApiService.Format")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/format"
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"multipart/form-data"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json", "text/plain"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	var inputLocalVarFormFileName string
+	var inputLocalVarFileName string
+	var inputLocalVarFileBytes []byte
+
+	inputLocalVarFormFileName = "input"
+
+	var inputLocalVarFile *os.File
+	if r.input != nil {
+		inputLocalVarFile = *r.input
+	}
+	if inputLocalVarFile != nil {
+		fbs, _ := ioutil.ReadAll(inputLocalVarFile)
+		inputLocalVarFileBytes = fbs
+		inputLocalVarFileName = inputLocalVarFile.Name()
+		inputLocalVarFile.Close()
+	}
+	formFiles = append(formFiles, formFile{fileBytes: inputLocalVarFileBytes, fileName: inputLocalVarFileName, formFileName: inputLocalVarFormFileName})
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	localVarBody, err := ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v string
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.model = v
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHTTPResponse, nil
+}
+
 type ApiHealthRequest struct {
 	ctx        context.Context
 	ApiService *Bai2FilesApiService
@@ -41,8 +174,8 @@ Health health bai2 service
 
 Check the bai2 service to check if running
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiHealthRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiHealthRequest
 */
 func (a *Bai2FilesApiService) Health(ctx context.Context) ApiHealthRequest {
 	return ApiHealthRequest{
@@ -52,7 +185,8 @@ func (a *Bai2FilesApiService) Health(ctx context.Context) ApiHealthRequest {
 }
 
 // Execute executes the request
-//  @return string
+//
+//	@return string
 func (a *Bai2FilesApiService) HealthExecute(r ApiHealthRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodGet
@@ -147,8 +281,8 @@ Parse Parse bai2 file after parse bin file
 
 parse bai2 file.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiParseRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiParseRequest
 */
 func (a *Bai2FilesApiService) Parse(ctx context.Context) ApiParseRequest {
 	return ApiParseRequest{
@@ -158,7 +292,8 @@ func (a *Bai2FilesApiService) Parse(ctx context.Context) ApiParseRequest {
 }
 
 // Execute executes the request
-//  @return string
+//
+//	@return string
 func (a *Bai2FilesApiService) ParseExecute(r ApiParseRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost
@@ -279,8 +414,8 @@ Print Print bai2 file after parse bin file
 
 Print bai2 file.
 
- @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- @return ApiPrintRequest
+	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	@return ApiPrintRequest
 */
 func (a *Bai2FilesApiService) Print(ctx context.Context) ApiPrintRequest {
 	return ApiPrintRequest{
@@ -290,7 +425,8 @@ func (a *Bai2FilesApiService) Print(ctx context.Context) ApiPrintRequest {
 }
 
 // Execute executes the request
-//  @return string
+//
+//	@return string
 func (a *Bai2FilesApiService) PrintExecute(r ApiPrintRequest) (string, *http.Response, error) {
 	var (
 		localVarHTTPMethod  = http.MethodPost

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"mime/multipart"
 	"net/http"
@@ -365,7 +366,7 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		return nil
 	}
 	if f, ok := v.(**os.File); ok {
-		*f, err = os.CreateTemp("", "HttpClientFile")
+		*f, err = ioutil.TempFile("", "HttpClientFile")
 		if err != nil {
 			return
 		}
@@ -447,11 +448,7 @@ func setBody(body interface{}, contentType string) (bodyBuf *bytes.Buffer, err e
 	} else if jsonCheck.MatchString(contentType) {
 		err = json.NewEncoder(bodyBuf).Encode(body)
 	} else if xmlCheck.MatchString(contentType) {
-		enc := xml.NewEncoder(bodyBuf)
-		err = enc.Encode(body)
-		if closeErr := enc.Close(); closeErr != nil {
-			err = fmt.Errorf("%v: close error %v", err, closeErr)
-		}
+		err = xml.NewEncoder(bodyBuf).Encode(body)
 	}
 
 	if err != nil {

--- a/pkg/client/docs/Bai2FilesApi.md
+++ b/pkg/client/docs/Bai2FilesApi.md
@@ -4,10 +4,77 @@ All URIs are relative to *http://localhost:8208*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**Format**](Bai2FilesApi.md#Format) | **Post** /format | Format bai2 file after parse bin file
 [**Health**](Bai2FilesApi.md#Health) | **Get** /health | health bai2 service
 [**Parse**](Bai2FilesApi.md#Parse) | **Post** /parse | Parse bai2 file after parse bin file
 [**Print**](Bai2FilesApi.md#Print) | **Post** /print | Print bai2 file after parse bin file
 
+
+
+## Format
+
+> map[string]interface{} Format(ctx).Input(input).Execute()
+
+Format bai2 file after parse bin file
+
+
+
+### Example
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "os"
+    openapiclient "./openapi"
+)
+
+func main() {
+    input := os.NewFile(1234, "some_file") // *os.File | bai2 bin file (optional)
+
+    configuration := openapiclient.NewConfiguration()
+    apiClient := openapiclient.NewAPIClient(configuration)
+    resp, r, err := apiClient.Bai2FilesApi.Format(context.Background()).Input(input).Execute()
+    if err != nil {
+        fmt.Fprintf(os.Stderr, "Error when calling `Bai2FilesApi.Format``: %v\n", err)
+        fmt.Fprintf(os.Stderr, "Full HTTP response: %v\n", r)
+    }
+    // response from `Format`: map[string]interface{}
+    fmt.Fprintf(os.Stdout, "Response from `Bai2FilesApi.Format`: %v\n", resp)
+}
+```
+
+### Path Parameters
+
+
+
+### Other Parameters
+
+Other parameters are passed through a pointer to a apiFormatRequest struct via the builder pattern
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **input** | ***os.File** | bai2 bin file | 
+
+### Return type
+
+**map[string]interface{}**
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: multipart/form-data
+- **Accept**: application/json, text/plain
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
 
 
 ## Health

--- a/pkg/service/handlers.go
+++ b/pkg/service/handlers.go
@@ -59,6 +59,16 @@ func outputBufferToWriter(w http.ResponseWriter, f *lib.Bai2) {
 	w.Write([]byte(f.String()))
 }
 
+func outputJsonBufferToWriter(w http.ResponseWriter, f *lib.Bai2) {
+	body, err := json.Marshal(f)
+	if err != nil {
+		panic(err)
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Write(body)
+}
+
 // parse - parse bai2 report
 func parse(w http.ResponseWriter, r *http.Request) {
 	f, err := parseInputFromRequest(r)
@@ -87,6 +97,17 @@ func print(w http.ResponseWriter, r *http.Request) {
 	outputBufferToWriter(w, f)
 }
 
+// format - format bai2 report after parse
+func format(w http.ResponseWriter, r *http.Request) {
+	f, err := parseInputFromRequest(r)
+	if err != nil {
+		outputError(w, http.StatusBadRequest, err)
+		return
+	}
+
+	outputJsonBufferToWriter(w, f)
+}
+
 // health - health check
 func health(w http.ResponseWriter, r *http.Request) {
 	outputSuccess(w, "alive")
@@ -98,6 +119,7 @@ func ConfigureHandlers(r *mux.Router) error {
 	r.HandleFunc("/health", health).Methods("GET")
 	r.HandleFunc("/print", print).Methods("POST")
 	r.HandleFunc("/parse", parse).Methods("POST")
+	r.HandleFunc("/format", format).Methods("POST")
 
 	return nil
 }

--- a/pkg/service/handlers_test.go
+++ b/pkg/service/handlers_test.go
@@ -105,3 +105,17 @@ func (suite *HandlersTest) TestParse() {
 	suite.testServer.ServeHTTP(recorder, request)
 	assert.Equal(suite.T(), http.StatusOK, recorder.Code)
 }
+
+func (suite *HandlersTest) TestFormat() {
+
+	writer, body := suite.getWriter(testFileName)
+	err := writer.Close()
+	assert.Equal(suite.T(), nil, err)
+
+	recorder, request := suite.makeRequest(http.MethodPost, "/format", body.String())
+	request.Header.Set("Content-Type", writer.FormDataContentType())
+
+	suite.testServer.ServeHTTP(recorder, request)
+	assert.Equal(suite.T(), http.StatusOK, recorder.Code)
+	assert.Equal(suite.T(), recorder.Body.String(), `{"sender":"0004","receiver":"12345","fileCreatedDate":"060321","fileCreatedTime":"0829","fileIdNumber":"001","physicalRecordLength":80,"blockSize":1,"versionNumber":2,"fileControlTotal":"+00000000001280000","numberOfGroups":1,"numberOfRecords":27,"Groups":[{"receiver":"12345","originator":"0004","groupStatus":1,"asOfDate":"060317","currencyCode":"CAD","groupControlTotal":"+00000000001280000","numberOfAccounts":2,"numberOfRecords":25,"Accounts":[{"accountNumber":"10200123456","currencyCode":"CAD","summaries":[{"TypeCode":"040","Amount":"+000000000000","ItemCount":0,"FundsType":{}},{"TypeCode":"045","Amount":"+000000000000","ItemCount":0,"FundsType":{}},{"TypeCode":"100","Amount":"000000000208500","ItemCount":3,"FundsType":{"type_code":"V","date":"060316"}},{"TypeCode":"400","Amount":"000000000208500","ItemCount":8,"FundsType":{"type_code":"V","date":"060316"}}],"accountControlTotal":"+00000000000834000","numberRecords":14,"Details":[{"TypeCode":"409","Amount":"000000000002500","FundsType":{"type_code":"V","date":"060316"},"BankReferenceNumber":"","CustomerReferenceNumber":"","Text":"RETURNED CHEQUE     "}]},{"accountNumber":"10200123456","currencyCode":"CAD","summaries":[{"TypeCode":"040","Amount":"+000000000000","ItemCount":0,"FundsType":{}},{"TypeCode":"045","Amount":"+000000000000","ItemCount":0,"FundsType":{}},{"TypeCode":"100","Amount":"000000000111500","ItemCount":2,"FundsType":{"type_code":"V","date":"060317"}},{"TypeCode":"400","Amount":"000000000111500","ItemCount":4,"FundsType":{"type_code":"V","date":"060317"}}],"accountControlTotal":"+00000000000446000","numberRecords":9,"Details":[{"TypeCode":"108","Amount":"000000000011500","FundsType":{"type_code":"V","date":"060317"},"BankReferenceNumber":"","CustomerReferenceNumber":"","Text":"TFR 1020 0345678    "}]}]}]}`)
+}


### PR DESCRIPTION
This change proposes a new endpoint for the BAI2 server that validates a BAI2 file and returns a JSON structure of the file. The returned JSON matches the structure that this library uses internally to represent a BAI2 file.