### PR TITLE
Normalize file paths in the fuzz test suite

### DIFF
--- a/test/fuzz/fuzz_test.go
+++ b/test/fuzz/fuzz_test.go
@@ -48,6 +48,8 @@ func populateCorpus(f *testing.F, errorFiles bool) {
 	f.Helper()
 
 	err := filepath.Walk(filepath.Join("..", "testdata"), func(path string, info fs.FileInfo, _ error) error {
+		path = filepath.ToSlash(path);
+
 		// Skip directories and some files
 		if info.IsDir() {
 			return nil


### PR DESCRIPTION
Due to the path separators being different on a windows machine vs a unix one, files in the errors directory were being ran by the fuzzing test suite. This one-liner should solve that problem.